### PR TITLE
Disqusのコメント欄が表示されなくなる状況を修正 ( RELATIVE_URLS = False でいけた )

### DIFF
--- a/2013/11/18/hello_new_blog.html
+++ b/2013/11/18/hello_new_blog.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="article"/>
             <meta property="og:title" content="ブログ移転"/>
-            <meta property="og:url" content="../../../2013/11/18/hello_new_blog.html"/>
+            <meta property="og:url" content="http://memo.laughk.org/2013/11/18/hello_new_blog.html"/>
             <meta property="og:description" content="これまでたまに ラフなラボ の方でブログを書いてましたが もう少し効率良くアウトプットしたいこともあって、 tinkerer + githubpage のこちらの環境に移行しました。 やっぱりReSTで書き留めたものをそのままBlogとして公開できるのは楽でいいですね。 (Octopress使わなかったのはMarkdownよりもReST使いたいから) 旧ブログを始めた頃に比べると大分目指すべき方向性も違ってきてしまっていたし、 まあ調度良いかなと。 このブログを立てる際の作業ログも後ほどまとめる予定。 ほとんど自分で面倒見なければいけないのはなかなか手間がかかった、、"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -75,7 +75,7 @@
                         2013-11-18
                 </span>
                 <h1>
-                    <a href="../../../2013/11/18/hello_new_blog.html"
+                    <a href="http://memo.laughk.org/2013/11/18/hello_new_blog.html"
                        rel="bookmark"
                        title="Permalink to ブログ移転">
                         ブログ移転
@@ -112,12 +112,12 @@ tinkerer + githubpage のこちらの環境に移行しました。
         <i class="fa fa-calendar"></i><time datetime="2013-11-18T00:00:00"> 2013-11-18</time>
     </span>
     <span class="label label-default">By</span>
-    <a href="../../../pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
+    <a href="http://memo.laughk.org/pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
 
 
 
 <span class="label label-default">Tags</span>
-	<a href="../../../tag/none.html">none</a>
+	<a href="http://memo.laughk.org/tag/none.html">none</a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
@@ -126,9 +126,9 @@ tinkerer + githubpage のこちらの環境に移行しました。
 <!-- AddThis Button BEGIN -->
 <div class="social_tools">
 
-    <a href="http://b.hatena.ne.jp/entry/../../../2013/11/18/hello_new_blog.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+    <a href="http://b.hatena.ne.jp/entry/http://memo.laughk.org/2013/11/18/hello_new_blog.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
 
-        <div class="fb-like" data-href="../../../2013/11/18/hello_new_blog.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
+        <div class="fb-like" data-href="http://memo.laughk.org/2013/11/18/hello_new_blog.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
 
         <a href="https://twitter.com/share" class="twitter-share-button addthis_button_tweet" data-lang="ja" data-related="laugh_k">ツイート</a>
 
@@ -190,8 +190,7 @@ tinkerer + githubpage のこちらの環境に移行しました。
         <script type="text/javascript">
             /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
             var disqus_shortname = 'memolaughkorg'; // required: replace example with your forum shortname
-            var disqus_identifier = 'hello_new_blog';
-            var disqus_url = '../../../2013/11/18/hello_new_blog.html';
+            var disqus_url = 'http://memo.laughk.org/2013/11/18/hello_new_blog.html';
             var disqus_config = function () {
                 this.language = "ja";
             };
@@ -244,31 +243,31 @@ tinkerer + githubpage のこちらの環境に移行しました。
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -302,10 +301,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/2013/11/21/irc_setup_in_terminal.html
+++ b/2013/11/21/irc_setup_in_terminal.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="article"/>
             <meta property="og:title" content="快適Terminal環境計画 - IRC -"/>
-            <meta property="og:url" content="../../../2013/11/21/irc_setup_in_terminal.html"/>
+            <meta property="og:url" content="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html"/>
             <meta property="og:description" content="前から tmux と組み合わせて irc bouncer 的な使い方をしていた weechat ですが。 いい加減本格的に移行したのでメモ。 ちなみに私は今のところ Ubuntu13.10 な 24時間起動のサーバ立てて使っとります。"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -75,7 +75,7 @@
                         2013-11-21
                 </span>
                 <h1>
-                    <a href="../../../2013/11/21/irc_setup_in_terminal.html"
+                    <a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html"
                        rel="bookmark"
                        title="Permalink to 快適Terminal環境計画 - IRC -">
                         快適Terminal環境計画 - IRC -
@@ -261,16 +261,16 @@ weechat-curses
         <i class="fa fa-calendar"></i><time datetime="2013-11-21T00:00:00"> 2013-11-21</time>
     </span>
     <span class="label label-default">By</span>
-    <a href="../../../pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
+    <a href="http://memo.laughk.org/pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
 
 
 
 <span class="label label-default">Tags</span>
-	<a href="../../../tag/terminal.html">terminal</a>
+	<a href="http://memo.laughk.org/tag/terminal.html">terminal</a>
         /
-	<a href="../../../tag/weechat.html">weechat</a>
+	<a href="http://memo.laughk.org/tag/weechat.html">weechat</a>
         /
-	<a href="../../../tag/irc.html">irc</a>
+	<a href="http://memo.laughk.org/tag/irc.html">irc</a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
@@ -279,9 +279,9 @@ weechat-curses
 <!-- AddThis Button BEGIN -->
 <div class="social_tools">
 
-    <a href="http://b.hatena.ne.jp/entry/../../../2013/11/21/irc_setup_in_terminal.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+    <a href="http://b.hatena.ne.jp/entry/http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
 
-        <div class="fb-like" data-href="../../../2013/11/21/irc_setup_in_terminal.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
+        <div class="fb-like" data-href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
 
         <a href="https://twitter.com/share" class="twitter-share-button addthis_button_tweet" data-lang="ja" data-related="laugh_k">ツイート</a>
 
@@ -343,8 +343,7 @@ weechat-curses
         <script type="text/javascript">
             /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
             var disqus_shortname = 'memolaughkorg'; // required: replace example with your forum shortname
-            var disqus_identifier = 'irc_setup_in_terminal';
-            var disqus_url = '../../../2013/11/21/irc_setup_in_terminal.html';
+            var disqus_url = 'http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html';
             var disqus_config = function () {
                 this.language = "ja";
             };
@@ -397,31 +396,31 @@ weechat-curses
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -455,10 +454,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/2013/12/10/ansible_with_infrastructure_engineer.html
+++ b/2013/12/10/ansible_with_infrastructure_engineer.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="article"/>
             <meta property="og:title" content="あるインフラエンジニアとAnsibleの付き合い方"/>
-            <meta property="og:url" content="../../../2013/12/10/ansible_with_infrastructure_engineer.html"/>
+            <meta property="og:url" content="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html"/>
             <meta property="og:description" content="この記事は Ansible Advent Calender 2013 10日目の記事です。 私は普段MSPな一応インフラエンジニア的なことをやっている人間ですが、 少しずつ今の仕事で ansible を利用し始めているのでその導入の際に障壁になったことや利用しているシーンを紹介したいと思います。"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -75,7 +75,7 @@
                         2013-12-10
                 </span>
                 <h1>
-                    <a href="../../../2013/12/10/ansible_with_infrastructure_engineer.html"
+                    <a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html"
                        rel="bookmark"
                        title="Permalink to あるインフラエンジニアとAnsibleの付き合い方">
                         あるインフラエンジニアとAnsibleの付き合い方
@@ -241,14 +241,14 @@ db01     <span class="nv">ansible_ssh_host</span><span class="o">=</span>192.168
         <i class="fa fa-calendar"></i><time datetime="2013-12-10T00:00:00"> 2013-12-10</time>
     </span>
     <span class="label label-default">By</span>
-    <a href="../../../pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
+    <a href="http://memo.laughk.org/pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
 
 
 
 <span class="label label-default">Tags</span>
-	<a href="../../../tag/ansible.html">ansible</a>
+	<a href="http://memo.laughk.org/tag/ansible.html">ansible</a>
         /
-	<a href="../../../tag/adventcalender.html">AdventCalender</a>
+	<a href="http://memo.laughk.org/tag/adventcalender.html">AdventCalender</a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
@@ -257,9 +257,9 @@ db01     <span class="nv">ansible_ssh_host</span><span class="o">=</span>192.168
 <!-- AddThis Button BEGIN -->
 <div class="social_tools">
 
-    <a href="http://b.hatena.ne.jp/entry/../../../2013/12/10/ansible_with_infrastructure_engineer.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+    <a href="http://b.hatena.ne.jp/entry/http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
 
-        <div class="fb-like" data-href="../../../2013/12/10/ansible_with_infrastructure_engineer.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
+        <div class="fb-like" data-href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
 
         <a href="https://twitter.com/share" class="twitter-share-button addthis_button_tweet" data-lang="ja" data-related="laugh_k">ツイート</a>
 
@@ -321,8 +321,7 @@ db01     <span class="nv">ansible_ssh_host</span><span class="o">=</span>192.168
         <script type="text/javascript">
             /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
             var disqus_shortname = 'memolaughkorg'; // required: replace example with your forum shortname
-            var disqus_identifier = 'ansible_with_infrastructure_engineer';
-            var disqus_url = '../../../2013/12/10/ansible_with_infrastructure_engineer.html';
+            var disqus_url = 'http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html';
             var disqus_config = function () {
                 this.language = "ja";
             };
@@ -375,31 +374,31 @@ db01     <span class="nv">ansible_ssh_host</span><span class="o">=</span>192.168
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -433,10 +432,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/2014/04/10/shell_lian_tower.html
+++ b/2014/04/10/shell_lian_tower.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="article"/>
             <meta property="og:title" content="久々に第10回記念シェル芸勉強会行ってきたんでまとめとか"/>
-            <meta property="og:url" content="../../../2014/04/10/shell_lian_tower.html"/>
+            <meta property="og:url" content="http://memo.laughk.org/2014/04/10/shell_lian_tower.html"/>
             <meta property="og:description" content="ブログ更新自体がかなりお久しぶりです。 何とか生きてました。身の回りの環境が最近がらりと変わったわけですが、 そのへんはまた近々別のエントリにでもしたいと思います。 今回は久々にシェル芸勉強会に行ってきたのでそのまとめを。 といいつつも、実際の会場の様子は以下の Togetter を見てもらったほうが早いかと。 第10回記念シェル芸勉強会@シェルリアンタワー&第28回場所が未定だったが決まったぞ定例会 - Togetterまとめ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -75,7 +75,7 @@
                         2014-04-10
                 </span>
                 <h1>
-                    <a href="../../../2014/04/10/shell_lian_tower.html"
+                    <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html"
                        rel="bookmark"
                        title="Permalink to 久々に第10回記念シェル芸勉強会行ってきたんでまとめとか">
                         久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
@@ -189,20 +189,20 @@ huga
         <i class="fa fa-calendar"></i><time datetime="2014-04-10T00:00:00"> 2014-04-10</time>
     </span>
     <span class="label label-default">By</span>
-    <a href="../../../pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
+    <a href="http://memo.laughk.org/pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
 
 
 
 <span class="label label-default">Tags</span>
-	<a href="../../../tag/shieruyun.html">シェル芸</a>
+	<a href="http://memo.laughk.org/tag/shieruyun.html">シェル芸</a>
         /
-	<a href="../../../tag/awk.html">awk</a>
+	<a href="http://memo.laughk.org/tag/awk.html">awk</a>
         /
-	<a href="../../../tag/grep.html">grep</a>
+	<a href="http://memo.laughk.org/tag/grep.html">grep</a>
         /
-	<a href="../../../tag/xargs.html">xargs</a>
+	<a href="http://memo.laughk.org/tag/xargs.html">xargs</a>
         /
-	<a href="../../../tag/mian-qiang-hui.html">勉強会</a>
+	<a href="http://memo.laughk.org/tag/mian-qiang-hui.html">勉強会</a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
@@ -211,9 +211,9 @@ huga
 <!-- AddThis Button BEGIN -->
 <div class="social_tools">
 
-    <a href="http://b.hatena.ne.jp/entry/../../../2014/04/10/shell_lian_tower.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+    <a href="http://b.hatena.ne.jp/entry/http://memo.laughk.org/2014/04/10/shell_lian_tower.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
 
-        <div class="fb-like" data-href="../../../2014/04/10/shell_lian_tower.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
+        <div class="fb-like" data-href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
 
         <a href="https://twitter.com/share" class="twitter-share-button addthis_button_tweet" data-lang="ja" data-related="laugh_k">ツイート</a>
 
@@ -275,8 +275,7 @@ huga
         <script type="text/javascript">
             /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
             var disqus_shortname = 'memolaughkorg'; // required: replace example with your forum shortname
-            var disqus_identifier = 'shell_lian_tower';
-            var disqus_url = '../../../2014/04/10/shell_lian_tower.html';
+            var disqus_url = 'http://memo.laughk.org/2014/04/10/shell_lian_tower.html';
             var disqus_config = function () {
                 this.language = "ja";
             };
@@ -329,31 +328,31 @@ huga
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -387,10 +386,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/2014/04/13/node_setagaya9_repo.html
+++ b/2014/04/13/node_setagaya9_repo.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="article"/>
             <meta property="og:title" content="NODE-SetagayaでTerminalのTips的なものを話してきた"/>
-            <meta property="og:url" content="../../../2014/04/13/node_setagaya9_repo.html"/>
+            <meta property="og:url" content="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html"/>
             <meta property="og:description" content="しばらくの間参加できていなかった NODE-Setagaya に参加& Terminal の Tips 的なものを話してきました。 当日利用したスライドはこちら。 Cli mini Hack!#1 ~Terminalとの親睦を深めよう~ Embed しようとすると Tinkerer のビルドが何故かコケるのでリンクのみ共有です。。Pelican に以降したらコケなくなったので埋め込みました！"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -75,7 +75,7 @@
                         2014-04-13
                 </span>
                 <h1>
-                    <a href="../../../2014/04/13/node_setagaya9_repo.html"
+                    <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html"
                        rel="bookmark"
                        title="Permalink to NODE-SetagayaでTerminalのTips的なものを話してきた">
                         NODE-SetagayaでTerminalのTips的なものを話してきた
@@ -149,20 +149,20 @@
         <i class="fa fa-calendar"></i><time datetime="2014-04-13T00:00:00"> 2014-04-13</time>
     </span>
     <span class="label label-default">By</span>
-    <a href="../../../pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
+    <a href="http://memo.laughk.org/pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
 
 
 
 <span class="label label-default">Tags</span>
-	<a href="../../../tag/mian-qiang-hui.html">勉強会</a>
+	<a href="http://memo.laughk.org/tag/mian-qiang-hui.html">勉強会</a>
         /
-	<a href="../../../tag/node-setagaya.html">NODE-Setagaya</a>
+	<a href="http://memo.laughk.org/tag/node-setagaya.html">NODE-Setagaya</a>
         /
-	<a href="../../../tag/terminal.html">Terminal</a>
+	<a href="http://memo.laughk.org/tag/terminal.html">Terminal</a>
         /
-	<a href="../../../tag/shieruyun.html">シェル芸</a>
+	<a href="http://memo.laughk.org/tag/shieruyun.html">シェル芸</a>
         /
-	<a href="../../../tag/vim.html">vim</a>
+	<a href="http://memo.laughk.org/tag/vim.html">vim</a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
@@ -171,9 +171,9 @@
 <!-- AddThis Button BEGIN -->
 <div class="social_tools">
 
-    <a href="http://b.hatena.ne.jp/entry/../../../2014/04/13/node_setagaya9_repo.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+    <a href="http://b.hatena.ne.jp/entry/http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
 
-        <div class="fb-like" data-href="../../../2014/04/13/node_setagaya9_repo.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
+        <div class="fb-like" data-href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
 
         <a href="https://twitter.com/share" class="twitter-share-button addthis_button_tweet" data-lang="ja" data-related="laugh_k">ツイート</a>
 
@@ -235,8 +235,7 @@
         <script type="text/javascript">
             /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
             var disqus_shortname = 'memolaughkorg'; // required: replace example with your forum shortname
-            var disqus_identifier = 'node_setagaya9_repo';
-            var disqus_url = '../../../2014/04/13/node_setagaya9_repo.html';
+            var disqus_url = 'http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html';
             var disqus_config = function () {
                 this.language = "ja";
             };
@@ -289,31 +288,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -347,10 +346,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/2014/04/21/qpstudy_20140419_report.html
+++ b/2014/04/21/qpstudy_20140419_report.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="article"/>
             <meta property="og:title" content="#qpstudy 2014.04 に参加してきたんで自分用まとめとか"/>
-            <meta property="og:url" content="../../../2014/04/21/qpstudy_20140419_report.html"/>
+            <meta property="og:url" content="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html"/>
             <meta property="og:description" content="だいぶ出遅れてしまいましたが、先週末 qpstudy 2014.04 に一般枠で参加させてもらってきたので 感想や学びになったことのまとめをメモしておきます。"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -75,7 +75,7 @@
                         2014-04-21
                 </span>
                 <h1>
-                    <a href="../../../2014/04/21/qpstudy_20140419_report.html"
+                    <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html"
                        rel="bookmark"
                        title="Permalink to #qpstudy 2014.04 に参加してきたんで自分用まとめとか">
                         #qpstudy 2014.04 に参加してきたんで自分用まとめとか
@@ -172,16 +172,16 @@
         <i class="fa fa-calendar"></i><time datetime="2014-04-21T00:00:00"> 2014-04-21</time>
     </span>
     <span class="label label-default">By</span>
-    <a href="../../../pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
+    <a href="http://memo.laughk.org/pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
 
 
 
 <span class="label label-default">Tags</span>
-	<a href="../../../tag/mian-qiang-hui.html">勉強会</a>
+	<a href="http://memo.laughk.org/tag/mian-qiang-hui.html">勉強会</a>
         /
-	<a href="../../../tag/qpstudy.html">qpstudy</a>
+	<a href="http://memo.laughk.org/tag/qpstudy.html">qpstudy</a>
         /
-	<a href="../../../tag/inhuraenzinia.html">インフラエンジニア</a>
+	<a href="http://memo.laughk.org/tag/inhuraenzinia.html">インフラエンジニア</a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
@@ -190,9 +190,9 @@
 <!-- AddThis Button BEGIN -->
 <div class="social_tools">
 
-    <a href="http://b.hatena.ne.jp/entry/../../../2014/04/21/qpstudy_20140419_report.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+    <a href="http://b.hatena.ne.jp/entry/http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
 
-        <div class="fb-like" data-href="../../../2014/04/21/qpstudy_20140419_report.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
+        <div class="fb-like" data-href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
 
         <a href="https://twitter.com/share" class="twitter-share-button addthis_button_tweet" data-lang="ja" data-related="laugh_k">ツイート</a>
 
@@ -254,8 +254,7 @@
         <script type="text/javascript">
             /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
             var disqus_shortname = 'memolaughkorg'; // required: replace example with your forum shortname
-            var disqus_identifier = 'qpstudy_20140419_report';
-            var disqus_url = '../../../2014/04/21/qpstudy_20140419_report.html';
+            var disqus_url = 'http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html';
             var disqus_config = function () {
                 this.language = "ja";
             };
@@ -308,31 +307,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -366,10 +365,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/2014/04/24/shell_exec_log.html
+++ b/2014/04/24/shell_exec_log.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="article"/>
             <meta property="og:title" content="シェルスクリプトが '> $logfile 2>&1' だらけにならなくて済んだ話"/>
-            <meta property="og:url" content="../../../2014/04/24/shell_exec_log.html"/>
+            <meta property="og:url" content="http://memo.laughk.org/2014/04/24/shell_exec_log.html"/>
             <meta property="og:description" content="※ 2014-04-26 追記並びに一部コマンド部分の修正を行いました。( > => >> に変更 ) 個人用のチラシの裏のつもりが予想以上に反響いただいていたようで非常にびっくりしております。 ちょっとしたバッチ処理的なものはさくっとシェルスクリプトでやっています。 で、ログをとっておくべくリダイレクトを噛ますわけですが、 スマートに書く方法を調べたのでメモ。 元ネタは @sechiro さんの bashのプロセス置換機能を活用して、シェル作業やスクリプト書きを効率化する でございます。 本当に参考になりました。ありがとうございます。"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -75,7 +75,7 @@
                         2014-04-24
                 </span>
                 <h1>
-                    <a href="../../../2014/04/24/shell_exec_log.html"
+                    <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html"
                        rel="bookmark"
                        title="Permalink to シェルスクリプトが '> $logfile 2>&1' だらけにならなくて済んだ話">
                         シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
@@ -231,12 +231,12 @@ command2
         <i class="fa fa-calendar"></i><time datetime="2014-04-24T00:00:00"> 2014-04-24</time>
     </span>
     <span class="label label-default">By</span>
-    <a href="../../../pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
+    <a href="http://memo.laughk.org/pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
 
 
 
 <span class="label label-default">Tags</span>
-	<a href="../../../tag/shellscript.html">shellscript</a>
+	<a href="http://memo.laughk.org/tag/shellscript.html">shellscript</a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
@@ -245,9 +245,9 @@ command2
 <!-- AddThis Button BEGIN -->
 <div class="social_tools">
 
-    <a href="http://b.hatena.ne.jp/entry/../../../2014/04/24/shell_exec_log.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+    <a href="http://b.hatena.ne.jp/entry/http://memo.laughk.org/2014/04/24/shell_exec_log.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
 
-        <div class="fb-like" data-href="../../../2014/04/24/shell_exec_log.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
+        <div class="fb-like" data-href="http://memo.laughk.org/2014/04/24/shell_exec_log.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
 
         <a href="https://twitter.com/share" class="twitter-share-button addthis_button_tweet" data-lang="ja" data-related="laugh_k">ツイート</a>
 
@@ -309,8 +309,7 @@ command2
         <script type="text/javascript">
             /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
             var disqus_shortname = 'memolaughkorg'; // required: replace example with your forum shortname
-            var disqus_identifier = 'shell_exec_log';
-            var disqus_url = '../../../2014/04/24/shell_exec_log.html';
+            var disqus_url = 'http://memo.laughk.org/2014/04/24/shell_exec_log.html';
             var disqus_config = function () {
                 this.language = "ja";
             };
@@ -363,31 +362,31 @@ command2
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -421,10 +420,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/2014/05/25/start_archlinux.html
+++ b/2014/05/25/start_archlinux.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="article"/>
             <meta property="og:title" content="Arch Linux はじめました"/>
-            <meta property="og:url" content="../../../2014/05/25/start_archlinux.html"/>
+            <meta property="og:url" content="http://memo.laughk.org/2014/05/25/start_archlinux.html"/>
             <meta property="og:description" content="Ubuntu14.04 のリリース情報もあり、 これまでDELL XPS13で使ってきた Linux Mint16 環境をどうしようかなと思っていましたが、 いろいろ考えて Linux Mint17 へのアップグレードは行わず、思い切って1週間ほど前に ArchLinux に引っ越しました。 概ね安定して使えてる感じがあります。 今回はインストールの際の簡単なメモとか、1周間ほど使ってみた感想とか。 ArchLinux は基本的な作業部分は公式 Wiki 見ればほとんど解決できるのであまりそういうことは書かないです。"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -75,7 +75,7 @@
                         2014-05-25
                 </span>
                 <h1>
-                    <a href="../../../2014/05/25/start_archlinux.html"
+                    <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html"
                        rel="bookmark"
                        title="Permalink to Arch Linux はじめました">
                         Arch Linux はじめました
@@ -450,14 +450,14 @@
         <i class="fa fa-calendar"></i><time datetime="2014-05-25T00:00:00"> 2014-05-25</time>
     </span>
     <span class="label label-default">By</span>
-    <a href="../../../pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
+    <a href="http://memo.laughk.org/pages/about.html"><i class="fa fa-user"></i> Kei Iwasaki</a>
 
 
 
 <span class="label label-default">Tags</span>
-	<a href="../../../tag/archlinux.html">ArchLinux</a>
+	<a href="http://memo.laughk.org/tag/archlinux.html">ArchLinux</a>
         /
-	<a href="../../../tag/huan-jing-gou-zhu.html">環境構築</a>
+	<a href="http://memo.laughk.org/tag/huan-jing-gou-zhu.html">環境構築</a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
@@ -466,9 +466,9 @@
 <!-- AddThis Button BEGIN -->
 <div class="social_tools">
 
-    <a href="http://b.hatena.ne.jp/entry/../../../2014/05/25/start_archlinux.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+    <a href="http://b.hatena.ne.jp/entry/http://memo.laughk.org/2014/05/25/start_archlinux.html" class="hatena-bookmark-button" data-hatena-bookmark-title="続・ラフなラボ" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
 
-        <div class="fb-like" data-href="../../../2014/05/25/start_archlinux.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
+        <div class="fb-like" data-href="http://memo.laughk.org/2014/05/25/start_archlinux.html" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
 
         <a href="https://twitter.com/share" class="twitter-share-button addthis_button_tweet" data-lang="ja" data-related="laugh_k">ツイート</a>
 
@@ -530,8 +530,7 @@
         <script type="text/javascript">
             /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
             var disqus_shortname = 'memolaughkorg'; // required: replace example with your forum shortname
-            var disqus_identifier = 'start_archlinux';
-            var disqus_url = '../../../2014/05/25/start_archlinux.html';
+            var disqus_url = 'http://memo.laughk.org/2014/05/25/start_archlinux.html';
             var disqus_config = function () {
                 this.language = "ja";
             };
@@ -584,31 +583,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -642,10 +641,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2013/11/18.html
+++ b/archives/2013/11/18.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,7 +71,7 @@
 
 <dl>
     <dt>2013-11-18</dt>
-    <dd><a href="../../../2013/11/18/hello_new_blog.html">ブログ移転</a></dd>
+    <dd><a href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">ブログ移転</a></dd>
 </dl>
         </div>
     </div>
@@ -104,31 +104,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -162,10 +162,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2013/11/21.html
+++ b/archives/2013/11/21.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,7 +71,7 @@
 
 <dl>
     <dt>2013-11-21</dt>
-    <dd><a href="../../../2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></dd>
+    <dd><a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></dd>
 </dl>
         </div>
     </div>
@@ -104,31 +104,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -162,10 +162,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2013/11/index.html
+++ b/archives/2013/11/index.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,9 +71,9 @@
 
 <dl>
     <dt>2013-11-21</dt>
-    <dd><a href="../../../2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></dd>
+    <dd><a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></dd>
     <dt>2013-11-18</dt>
-    <dd><a href="../../../2013/11/18/hello_new_blog.html">ブログ移転</a></dd>
+    <dd><a href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">ブログ移転</a></dd>
 </dl>
         </div>
     </div>
@@ -106,31 +106,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -164,10 +164,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2013/12/10.html
+++ b/archives/2013/12/10.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,7 +71,7 @@
 
 <dl>
     <dt>2013-12-10</dt>
-    <dd><a href="../../../2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></dd>
+    <dd><a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></dd>
 </dl>
         </div>
     </div>
@@ -104,31 +104,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -162,10 +162,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2013/12/index.html
+++ b/archives/2013/12/index.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,7 +71,7 @@
 
 <dl>
     <dt>2013-12-10</dt>
-    <dd><a href="../../../2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></dd>
+    <dd><a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></dd>
 </dl>
         </div>
     </div>
@@ -104,31 +104,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -162,10 +162,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2013/index.html
+++ b/archives/2013/index.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../theme/css/style.css" type="text/css"/>
-        <link href="../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,11 +71,11 @@
 
 <dl>
     <dt>2013-12-10</dt>
-    <dd><a href="../../2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></dd>
+    <dd><a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></dd>
     <dt>2013-11-21</dt>
-    <dd><a href="../../2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></dd>
+    <dd><a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></dd>
     <dt>2013-11-18</dt>
-    <dd><a href="../../2013/11/18/hello_new_blog.html">ブログ移転</a></dd>
+    <dd><a href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">ブログ移転</a></dd>
 </dl>
         </div>
     </div>
@@ -108,31 +108,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -166,10 +166,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2014/04/10.html
+++ b/archives/2014/04/10.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,7 +71,7 @@
 
 <dl>
     <dt>2014-04-10</dt>
-    <dd><a href="../../../2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></dd>
 </dl>
         </div>
     </div>
@@ -104,31 +104,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -162,10 +162,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2014/04/13.html
+++ b/archives/2014/04/13.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,7 +71,7 @@
 
 <dl>
     <dt>2014-04-13</dt>
-    <dd><a href="../../../2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></dd>
 </dl>
         </div>
     </div>
@@ -104,31 +104,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -162,10 +162,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2014/04/21.html
+++ b/archives/2014/04/21.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,7 +71,7 @@
 
 <dl>
     <dt>2014-04-21</dt>
-    <dd><a href="../../../2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></dd>
 </dl>
         </div>
     </div>
@@ -104,31 +104,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -162,10 +162,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2014/04/24.html
+++ b/archives/2014/04/24.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,7 +71,7 @@
 
 <dl>
     <dt>2014-04-24</dt>
-    <dd><a href="../../../2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></dd>
 </dl>
         </div>
     </div>
@@ -104,31 +104,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -162,10 +162,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2014/04/index.html
+++ b/archives/2014/04/index.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,13 +71,13 @@
 
 <dl>
     <dt>2014-04-24</dt>
-    <dd><a href="../../../2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></dd>
     <dt>2014-04-21</dt>
-    <dd><a href="../../../2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></dd>
     <dt>2014-04-13</dt>
-    <dd><a href="../../../2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></dd>
     <dt>2014-04-10</dt>
-    <dd><a href="../../../2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></dd>
 </dl>
         </div>
     </div>
@@ -110,31 +110,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -168,10 +168,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2014/05/25.html
+++ b/archives/2014/05/25.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,7 +71,7 @@
 
 <dl>
     <dt>2014-05-25</dt>
-    <dd><a href="../../../2014/05/25/start_archlinux.html">Arch Linux はじめました</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Arch Linux はじめました</a></dd>
 </dl>
         </div>
     </div>
@@ -104,31 +104,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -162,10 +162,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2014/05/index.html
+++ b/archives/2014/05/index.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../../theme/css/style.css" type="text/css"/>
-        <link href="../../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,7 +71,7 @@
 
 <dl>
     <dt>2014-05-25</dt>
-    <dd><a href="../../../2014/05/25/start_archlinux.html">Arch Linux はじめました</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Arch Linux はじめました</a></dd>
 </dl>
         </div>
     </div>
@@ -104,31 +104,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -162,10 +162,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/2014/index.html
+++ b/archives/2014/index.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="../.."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../../theme/css/style.css" type="text/css"/>
-        <link href="../../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -71,15 +71,15 @@
 
 <dl>
     <dt>2014-05-25</dt>
-    <dd><a href="../../2014/05/25/start_archlinux.html">Arch Linux はじめました</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Arch Linux はじめました</a></dd>
     <dt>2014-04-24</dt>
-    <dd><a href="../../2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></dd>
     <dt>2014-04-21</dt>
-    <dd><a href="../../2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></dd>
     <dt>2014-04-13</dt>
-    <dd><a href="../../2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></dd>
     <dt>2014-04-10</dt>
-    <dd><a href="../../2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></dd>
+    <dd><a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></dd>
 </dl>
         </div>
     </div>
@@ -112,31 +112,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -170,10 +170,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/archives/index.html
+++ b/archives/index.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,21 +72,21 @@
 
         <dl>
                 <dt>2014-05-25</dt>
-                <dd><a href='../2014/05/25/start_archlinux.html'>Arch Linux はじめました</a></dd>
+                <dd><a href='http://memo.laughk.org/2014/05/25/start_archlinux.html'>Arch Linux はじめました</a></dd>
                 <dt>2014-04-24</dt>
-                <dd><a href='../2014/04/24/shell_exec_log.html'>シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></dd>
+                <dd><a href='http://memo.laughk.org/2014/04/24/shell_exec_log.html'>シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></dd>
                 <dt>2014-04-21</dt>
-                <dd><a href='../2014/04/21/qpstudy_20140419_report.html'>#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></dd>
+                <dd><a href='http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html'>#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></dd>
                 <dt>2014-04-13</dt>
-                <dd><a href='../2014/04/13/node_setagaya9_repo.html'>NODE-SetagayaでTerminalのTips的なものを話してきた</a></dd>
+                <dd><a href='http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html'>NODE-SetagayaでTerminalのTips的なものを話してきた</a></dd>
                 <dt>2014-04-10</dt>
-                <dd><a href='../2014/04/10/shell_lian_tower.html'>久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></dd>
+                <dd><a href='http://memo.laughk.org/2014/04/10/shell_lian_tower.html'>久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></dd>
                 <dt>2013-12-10</dt>
-                <dd><a href='../2013/12/10/ansible_with_infrastructure_engineer.html'>あるインフラエンジニアとAnsibleの付き合い方</a></dd>
+                <dd><a href='http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html'>あるインフラエンジニアとAnsibleの付き合い方</a></dd>
                 <dt>2013-11-21</dt>
-                <dd><a href='../2013/11/21/irc_setup_in_terminal.html'>快適Terminal環境計画 - IRC -</a></dd>
+                <dd><a href='http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html'>快適Terminal環境計画 - IRC -</a></dd>
                 <dt>2013-11-18</dt>
-                <dd><a href='../2013/11/18/hello_new_blog.html'>ブログ移転</a></dd>
+                <dd><a href='http://memo.laughk.org/2013/11/18/hello_new_blog.html'>ブログ移転</a></dd>
         </dl>
     </section>
         </div>
@@ -120,31 +120,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -178,10 +178,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/categories.html
+++ b/categories.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="./images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="./theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="./theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="./theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="./theme/css/style.css" type="text/css"/>
-        <link href="./static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="./atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="./rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="./" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="./pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="./archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -78,14 +78,14 @@
                 </div>
                 <div id="collapse-misc" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2014-05-25T00:00:00">2014-05-25</time></span> <a href="./2014/05/25/start_archlinux.html">Arch Linux はじめました</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2014-04-24T00:00:00">2014-04-24</time></span> <a href="./2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2014-04-21T00:00:00">2014-04-21</time></span> <a href="./2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2014-04-13T00:00:00">2014-04-13</time></span> <a href="./2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2014-04-10T00:00:00">2014-04-10</time></span> <a href="./2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-12-10T00:00:00">2013-12-10</time></span> <a href="./2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-11-21T00:00:00">2013-11-21</time></span> <a href="./2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-11-18T00:00:00">2013-11-18</time></span> <a href="./2013/11/18/hello_new_blog.html">ブログ移転</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-05-25T00:00:00">2014-05-25</time></span> <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Arch Linux はじめました</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-04-24T00:00:00">2014-04-24</time></span> <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-04-21T00:00:00">2014-04-21</time></span> <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-04-13T00:00:00">2014-04-13</time></span> <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-04-10T00:00:00">2014-04-10</time></span> <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-12-10T00:00:00">2013-12-10</time></span> <a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-11-21T00:00:00">2013-11-21</time></span> <a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-11-18T00:00:00">2013-11-18</time></span> <a href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">ブログ移転</a></p>
                     </div>
                 </div>
             </div>
@@ -123,31 +123,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="./2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="./2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="./2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="./2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="./2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -181,10 +181,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="./theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="./theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/category/misc.html
+++ b/category/misc.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,7 +72,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-05-25
                 </span>
-                <h2><a href="../2014/05/25/start_archlinux.html">Arch Linux はじめました</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Arch Linux はじめました</a></h2>
                 <div class="summary"><img alt="" src="/images/2014/05/25/screenshot1.png" />
 <div class="line-block">
 <div class="line"><tt class="docutils literal">Ubuntu14.04</tt> のリリース情報もあり、</div>
@@ -84,8 +84,8 @@
 <div class="line"><tt class="docutils literal">ArchLinux</tt> は基本的な作業部分は公式 <tt class="docutils literal">Wiki</tt> 見ればほとんど解決できるのであまりそういうことは書かないです。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/05/25/start_archlinux.html">Read more ...</a>
-                    <!-- <a href="../2014/05/25/start_archlinux.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -94,7 +94,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-24
                 </span>
-                <h2><a href="../2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></h2>
                 <div class="summary"><dl class="docutils">
 <dt>※ 2014-04-26</dt>
 <dd><div class="first last line-block">
@@ -113,8 +113,8 @@
 <div class="line">本当に参考になりました。ありがとうございます。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/24/shell_exec_log.html">Read more ...</a>
-                    <!-- <a href="../2014/04/24/shell_exec_log.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -123,14 +123,14 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-21
                 </span>
-                <h2><a href="../2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">だいぶ出遅れてしまいましたが、先週末 <a class="reference external" href="http://www.zusaar.com/event/4897007">qpstudy 2014.04</a> に一般枠で参加させてもらってきたので</div>
 <div class="line">感想や学びになったことのまとめをメモしておきます。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/21/qpstudy_20140419_report.html">Read more ...</a>
-                    <!-- <a href="../2014/04/21/qpstudy_20140419_report.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -139,7 +139,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-13
                 </span>
-                <h2><a href="../2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
                 <div class="summary"><p>しばらくの間参加できていなかった <tt class="docutils literal"><span class="pre">NODE-Setagaya</span></tt> に参加&amp; <tt class="docutils literal">Terminal</tt> の <tt class="docutils literal">Tips</tt> 的なものを話してきました。
 当日利用したスライドはこちら。</p>
 <div style="width: 65%">
@@ -147,8 +147,8 @@
 </div><p><a class="reference external" href="https://speakerdeck.com/laughk/cli-mini-hack-number-1-terminaltofalseqin-mu-woshen-meyou">Cli mini Hack!#1 ~Terminalとの親睦を深めよう~</a></p>
 <s>Embed しようとすると Tinkerer のビルドが何故かコケるのでリンクのみ共有です。。</s><p><tt class="docutils literal">Pelican</tt> に以降したらコケなくなったので埋め込みました！</p>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/13/node_setagaya9_repo.html">Read more ...</a>
-                    <!-- <a href="../2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -157,7 +157,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-10
                 </span>
-                <h2><a href="../2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">ブログ更新自体がかなりお久しぶりです。</div>
 <div class="line">何とか生きてました。身の回りの環境が最近がらりと変わったわけですが、</div>
@@ -171,8 +171,8 @@
 <li><a class="reference external" href="http://togetter.com/li/651837">第10回記念シェル芸勉強会&#64;シェルリアンタワー&amp;第28回場所が未定だったが決まったぞ定例会 - Togetterまとめ</a></li>
 </ul>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/10/shell_lian_tower.html">Read more ...</a>
-                    <!-- <a href="../2014/04/10/shell_lian_tower.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -181,13 +181,13 @@
                     <i class="fa fa-calendar"></i>
                         2013-12-10
                 </span>
-                <h2><a href="../2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></h2>
+                <h2><a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></h2>
                 <div class="summary"><p>この記事は <a class="reference external" href="http://qiita.com/advent-calendar/2013/ansible">Ansible Advent Calender 2013</a> 10日目の記事です。</p>
 <p>私は普段MSPな一応インフラエンジニア的なことをやっている人間ですが、
 少しずつ今の仕事で <tt class="docutils literal">ansible</tt> を利用し始めているのでその導入の際に障壁になったことや利用しているシーンを紹介したいと思います。</p>
 
-                    <a class="btn btn-primary btn-xs" href="../2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a>
-                    <!-- <a href="../2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -196,15 +196,15 @@
                     <i class="fa fa-calendar"></i>
                         2013-11-21
                 </span>
-                <h2><a href="../2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></h2>
+                <h2><a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">前から tmux と組み合わせて irc bouncer 的な使い方をしていた weechat ですが。</div>
 <div class="line">いい加減本格的に移行したのでメモ。</div>
 <div class="line">ちなみに私は今のところ Ubuntu13.10 な 24時間起動のサーバ立てて使っとります。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="../2013/11/21/irc_setup_in_terminal.html">Read more ...</a>
-                    <!-- <a href="../2013/11/21/irc_setup_in_terminal.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -213,7 +213,7 @@
                     <i class="fa fa-calendar"></i>
                         2013-11-18
                 </span>
-                <h2><a href="../2013/11/18/hello_new_blog.html">ブログ移転</a></h2>
+                <h2><a href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">ブログ移転</a></h2>
                 <div class="summary"><p>これまでたまに <a class="reference external" href="http://laugh-labo.blogspot.com">ラフなラボ</a> の方でブログを書いてましたが
 もう少し効率良くアウトプットしたいこともあって、
 tinkerer + githubpage のこちらの環境に移行しました。
@@ -224,8 +224,8 @@ tinkerer + githubpage のこちらの環境に移行しました。
 <p>このブログを立てる際の作業ログも後ほどまとめる予定。
 ほとんど自分で面倒見なければいけないのはなかなか手間がかかった、、</p>
 
-                    <a class="btn btn-primary btn-xs" href="../2013/11/18/hello_new_blog.html">Read more ...</a>
-                    <!-- <a href="../2013/11/18/hello_new_blog.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -261,31 +261,31 @@ tinkerer + githubpage のこちらの環境に移行しました。
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -319,10 +319,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/index.html
+++ b/index.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="./images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content="."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="./theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="./theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="./theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="./theme/css/style.css" type="text/css"/>
-        <link href="./static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="./atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="./rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="./" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="./pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="./archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,7 +72,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-05-25
                 </span>
-                <h2><a href="./2014/05/25/start_archlinux.html">Arch Linux はじめました</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Arch Linux はじめました</a></h2>
                 <div class="summary"><img alt="" src="/images/2014/05/25/screenshot1.png" />
 <div class="line-block">
 <div class="line"><tt class="docutils literal">Ubuntu14.04</tt> のリリース情報もあり、</div>
@@ -84,8 +84,8 @@
 <div class="line"><tt class="docutils literal">ArchLinux</tt> は基本的な作業部分は公式 <tt class="docutils literal">Wiki</tt> 見ればほとんど解決できるのであまりそういうことは書かないです。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="./2014/05/25/start_archlinux.html">Read more ...</a>
-                    <!-- <a href="./2014/05/25/start_archlinux.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -94,7 +94,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-24
                 </span>
-                <h2><a href="./2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></h2>
                 <div class="summary"><dl class="docutils">
 <dt>※ 2014-04-26</dt>
 <dd><div class="first last line-block">
@@ -113,8 +113,8 @@
 <div class="line">本当に参考になりました。ありがとうございます。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="./2014/04/24/shell_exec_log.html">Read more ...</a>
-                    <!-- <a href="./2014/04/24/shell_exec_log.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -123,14 +123,14 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-21
                 </span>
-                <h2><a href="./2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">だいぶ出遅れてしまいましたが、先週末 <a class="reference external" href="http://www.zusaar.com/event/4897007">qpstudy 2014.04</a> に一般枠で参加させてもらってきたので</div>
 <div class="line">感想や学びになったことのまとめをメモしておきます。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="./2014/04/21/qpstudy_20140419_report.html">Read more ...</a>
-                    <!-- <a href="./2014/04/21/qpstudy_20140419_report.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -139,7 +139,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-13
                 </span>
-                <h2><a href="./2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
                 <div class="summary"><p>しばらくの間参加できていなかった <tt class="docutils literal"><span class="pre">NODE-Setagaya</span></tt> に参加&amp; <tt class="docutils literal">Terminal</tt> の <tt class="docutils literal">Tips</tt> 的なものを話してきました。
 当日利用したスライドはこちら。</p>
 <div style="width: 65%">
@@ -147,8 +147,8 @@
 </div><p><a class="reference external" href="https://speakerdeck.com/laughk/cli-mini-hack-number-1-terminaltofalseqin-mu-woshen-meyou">Cli mini Hack!#1 ~Terminalとの親睦を深めよう~</a></p>
 <s>Embed しようとすると Tinkerer のビルドが何故かコケるのでリンクのみ共有です。。</s><p><tt class="docutils literal">Pelican</tt> に以降したらコケなくなったので埋め込みました！</p>
 
-                    <a class="btn btn-primary btn-xs" href="./2014/04/13/node_setagaya9_repo.html">Read more ...</a>
-                    <!-- <a href="./2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -157,7 +157,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-10
                 </span>
-                <h2><a href="./2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">ブログ更新自体がかなりお久しぶりです。</div>
 <div class="line">何とか生きてました。身の回りの環境が最近がらりと変わったわけですが、</div>
@@ -171,8 +171,8 @@
 <li><a class="reference external" href="http://togetter.com/li/651837">第10回記念シェル芸勉強会&#64;シェルリアンタワー&amp;第28回場所が未定だったが決まったぞ定例会 - Togetterまとめ</a></li>
 </ul>
 
-                    <a class="btn btn-primary btn-xs" href="./2014/04/10/shell_lian_tower.html">Read more ...</a>
-                    <!-- <a href="./2014/04/10/shell_lian_tower.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -181,13 +181,13 @@
                     <i class="fa fa-calendar"></i>
                         2013-12-10
                 </span>
-                <h2><a href="./2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></h2>
+                <h2><a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></h2>
                 <div class="summary"><p>この記事は <a class="reference external" href="http://qiita.com/advent-calendar/2013/ansible">Ansible Advent Calender 2013</a> 10日目の記事です。</p>
 <p>私は普段MSPな一応インフラエンジニア的なことをやっている人間ですが、
 少しずつ今の仕事で <tt class="docutils literal">ansible</tt> を利用し始めているのでその導入の際に障壁になったことや利用しているシーンを紹介したいと思います。</p>
 
-                    <a class="btn btn-primary btn-xs" href="./2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a>
-                    <!-- <a href="./2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -196,15 +196,15 @@
                     <i class="fa fa-calendar"></i>
                         2013-11-21
                 </span>
-                <h2><a href="./2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></h2>
+                <h2><a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">前から tmux と組み合わせて irc bouncer 的な使い方をしていた weechat ですが。</div>
 <div class="line">いい加減本格的に移行したのでメモ。</div>
 <div class="line">ちなみに私は今のところ Ubuntu13.10 な 24時間起動のサーバ立てて使っとります。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="./2013/11/21/irc_setup_in_terminal.html">Read more ...</a>
-                    <!-- <a href="./2013/11/21/irc_setup_in_terminal.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -213,7 +213,7 @@
                     <i class="fa fa-calendar"></i>
                         2013-11-18
                 </span>
-                <h2><a href="./2013/11/18/hello_new_blog.html">ブログ移転</a></h2>
+                <h2><a href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">ブログ移転</a></h2>
                 <div class="summary"><p>これまでたまに <a class="reference external" href="http://laugh-labo.blogspot.com">ラフなラボ</a> の方でブログを書いてましたが
 もう少し効率良くアウトプットしたいこともあって、
 tinkerer + githubpage のこちらの環境に移行しました。
@@ -224,8 +224,8 @@ tinkerer + githubpage のこちらの環境に移行しました。
 <p>このブログを立てる際の作業ログも後ほどまとめる予定。
 ほとんど自分で面倒見なければいけないのはなかなか手間がかかった、、</p>
 
-                    <a class="btn btn-primary btn-xs" href="./2013/11/18/hello_new_blog.html">Read more ...</a>
-                    <!-- <a href="./2013/11/18/hello_new_blog.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -261,31 +261,31 @@ tinkerer + githubpage のこちらの環境に移行しました。
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="./2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="./2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="./2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="./2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="./2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -319,10 +319,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="./theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="./theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/pages/about.html
+++ b/pages/about.html
@@ -9,24 +9,24 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="article"/>
             <meta property="og:title" content="About Me"/>
-            <meta property="og:url" content="../pages/about.html"/>
+            <meta property="og:url" content="http://memo.laughk.org/pages/about.html"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -41,7 +41,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -50,12 +50,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li class="active"><a href="../pages/about.html">
+                         <li class="active"><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -128,31 +128,31 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -186,10 +186,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/adventcalender.html
+++ b/tag/adventcalender.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,13 +72,13 @@
                     <i class="fa fa-calendar"></i>
                         2013-12-10
                 </span>
-                <h2><a href="../2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></h2>
+                <h2><a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></h2>
                 <div class="summary"><p>この記事は <a class="reference external" href="http://qiita.com/advent-calendar/2013/ansible">Ansible Advent Calender 2013</a> 10日目の記事です。</p>
 <p>私は普段MSPな一応インフラエンジニア的なことをやっている人間ですが、
 少しずつ今の仕事で <tt class="docutils literal">ansible</tt> を利用し始めているのでその導入の際に障壁になったことや利用しているシーンを紹介したいと思います。</p>
 
-                    <a class="btn btn-primary btn-xs" href="../2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a>
-                    <!-- <a href="../2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -114,7 +114,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2013/12/10/ansible_with_infrastructure_engineer.html">
+        <a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">
             あるインフラエンジニアとAnsibleの付き合い方
         </a>
     </li>
@@ -148,10 +148,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/ansible.html
+++ b/tag/ansible.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,13 +72,13 @@
                     <i class="fa fa-calendar"></i>
                         2013-12-10
                 </span>
-                <h2><a href="../2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></h2>
+                <h2><a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">あるインフラエンジニアとAnsibleの付き合い方</a></h2>
                 <div class="summary"><p>この記事は <a class="reference external" href="http://qiita.com/advent-calendar/2013/ansible">Ansible Advent Calender 2013</a> 10日目の記事です。</p>
 <p>私は普段MSPな一応インフラエンジニア的なことをやっている人間ですが、
 少しずつ今の仕事で <tt class="docutils literal">ansible</tt> を利用し始めているのでその導入の際に障壁になったことや利用しているシーンを紹介したいと思います。</p>
 
-                    <a class="btn btn-primary btn-xs" href="../2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a>
-                    <!-- <a href="../2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -114,7 +114,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2013/12/10/ansible_with_infrastructure_engineer.html">
+        <a href="http://memo.laughk.org/2013/12/10/ansible_with_infrastructure_engineer.html">
             あるインフラエンジニアとAnsibleの付き合い方
         </a>
     </li>
@@ -148,10 +148,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/archlinux.html
+++ b/tag/archlinux.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,7 +72,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-05-25
                 </span>
-                <h2><a href="../2014/05/25/start_archlinux.html">Arch Linux はじめました</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Arch Linux はじめました</a></h2>
                 <div class="summary"><img alt="" src="/images/2014/05/25/screenshot1.png" />
 <div class="line-block">
 <div class="line"><tt class="docutils literal">Ubuntu14.04</tt> のリリース情報もあり、</div>
@@ -84,8 +84,8 @@
 <div class="line"><tt class="docutils literal">ArchLinux</tt> は基本的な作業部分は公式 <tt class="docutils literal">Wiki</tt> 見ればほとんど解決できるのであまりそういうことは書かないです。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/05/25/start_archlinux.html">Read more ...</a>
-                    <!-- <a href="../2014/05/25/start_archlinux.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -121,7 +121,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
@@ -155,10 +155,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/awk.html
+++ b/tag/awk.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,7 +72,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-10
                 </span>
-                <h2><a href="../2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">ブログ更新自体がかなりお久しぶりです。</div>
 <div class="line">何とか生きてました。身の回りの環境が最近がらりと変わったわけですが、</div>
@@ -86,8 +86,8 @@
 <li><a class="reference external" href="http://togetter.com/li/651837">第10回記念シェル芸勉強会&#64;シェルリアンタワー&amp;第28回場所が未定だったが決まったぞ定例会 - Togetterまとめ</a></li>
 </ul>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/10/shell_lian_tower.html">Read more ...</a>
-                    <!-- <a href="../2014/04/10/shell_lian_tower.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -123,7 +123,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -157,10 +157,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/grep.html
+++ b/tag/grep.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,7 +72,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-10
                 </span>
-                <h2><a href="../2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">ブログ更新自体がかなりお久しぶりです。</div>
 <div class="line">何とか生きてました。身の回りの環境が最近がらりと変わったわけですが、</div>
@@ -86,8 +86,8 @@
 <li><a class="reference external" href="http://togetter.com/li/651837">第10回記念シェル芸勉強会&#64;シェルリアンタワー&amp;第28回場所が未定だったが決まったぞ定例会 - Togetterまとめ</a></li>
 </ul>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/10/shell_lian_tower.html">Read more ...</a>
-                    <!-- <a href="../2014/04/10/shell_lian_tower.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -123,7 +123,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -157,10 +157,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/huan-jing-gou-zhu.html
+++ b/tag/huan-jing-gou-zhu.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,7 +72,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-05-25
                 </span>
-                <h2><a href="../2014/05/25/start_archlinux.html">Arch Linux はじめました</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Arch Linux はじめました</a></h2>
                 <div class="summary"><img alt="" src="/images/2014/05/25/screenshot1.png" />
 <div class="line-block">
 <div class="line"><tt class="docutils literal">Ubuntu14.04</tt> のリリース情報もあり、</div>
@@ -84,8 +84,8 @@
 <div class="line"><tt class="docutils literal">ArchLinux</tt> は基本的な作業部分は公式 <tt class="docutils literal">Wiki</tt> 見ればほとんど解決できるのであまりそういうことは書かないです。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/05/25/start_archlinux.html">Read more ...</a>
-                    <!-- <a href="../2014/05/25/start_archlinux.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -121,7 +121,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/05/25/start_archlinux.html">
+        <a href="http://memo.laughk.org/2014/05/25/start_archlinux.html">
             Arch Linux はじめました
         </a>
     </li>
@@ -155,10 +155,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/inhuraenzinia.html
+++ b/tag/inhuraenzinia.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,14 +72,14 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-21
                 </span>
-                <h2><a href="../2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">だいぶ出遅れてしまいましたが、先週末 <a class="reference external" href="http://www.zusaar.com/event/4897007">qpstudy 2014.04</a> に一般枠で参加させてもらってきたので</div>
 <div class="line">感想や学びになったことのまとめをメモしておきます。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/21/qpstudy_20140419_report.html">Read more ...</a>
-                    <!-- <a href="../2014/04/21/qpstudy_20140419_report.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -115,7 +115,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
@@ -149,10 +149,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/irc.html
+++ b/tag/irc.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,15 +72,15 @@
                     <i class="fa fa-calendar"></i>
                         2013-11-21
                 </span>
-                <h2><a href="../2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></h2>
+                <h2><a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">前から tmux と組み合わせて irc bouncer 的な使い方をしていた weechat ですが。</div>
 <div class="line">いい加減本格的に移行したのでメモ。</div>
 <div class="line">ちなみに私は今のところ Ubuntu13.10 な 24時間起動のサーバ立てて使っとります。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="../2013/11/21/irc_setup_in_terminal.html">Read more ...</a>
-                    <!-- <a href="../2013/11/21/irc_setup_in_terminal.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -116,7 +116,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2013/11/21/irc_setup_in_terminal.html">
+        <a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">
             快適Terminal環境計画 - IRC -
         </a>
     </li>
@@ -150,10 +150,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/mian-qiang-hui.html
+++ b/tag/mian-qiang-hui.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,14 +72,14 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-21
                 </span>
-                <h2><a href="../2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">だいぶ出遅れてしまいましたが、先週末 <a class="reference external" href="http://www.zusaar.com/event/4897007">qpstudy 2014.04</a> に一般枠で参加させてもらってきたので</div>
 <div class="line">感想や学びになったことのまとめをメモしておきます。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/21/qpstudy_20140419_report.html">Read more ...</a>
-                    <!-- <a href="../2014/04/21/qpstudy_20140419_report.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -88,7 +88,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-13
                 </span>
-                <h2><a href="../2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
                 <div class="summary"><p>しばらくの間参加できていなかった <tt class="docutils literal"><span class="pre">NODE-Setagaya</span></tt> に参加&amp; <tt class="docutils literal">Terminal</tt> の <tt class="docutils literal">Tips</tt> 的なものを話してきました。
 当日利用したスライドはこちら。</p>
 <div style="width: 65%">
@@ -96,8 +96,8 @@
 </div><p><a class="reference external" href="https://speakerdeck.com/laughk/cli-mini-hack-number-1-terminaltofalseqin-mu-woshen-meyou">Cli mini Hack!#1 ~Terminalとの親睦を深めよう~</a></p>
 <s>Embed しようとすると Tinkerer のビルドが何故かコケるのでリンクのみ共有です。。</s><p><tt class="docutils literal">Pelican</tt> に以降したらコケなくなったので埋め込みました！</p>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/13/node_setagaya9_repo.html">Read more ...</a>
-                    <!-- <a href="../2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -106,7 +106,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-10
                 </span>
-                <h2><a href="../2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">ブログ更新自体がかなりお久しぶりです。</div>
 <div class="line">何とか生きてました。身の回りの環境が最近がらりと変わったわけですが、</div>
@@ -120,8 +120,8 @@
 <li><a class="reference external" href="http://togetter.com/li/651837">第10回記念シェル芸勉強会&#64;シェルリアンタワー&amp;第28回場所が未定だったが決まったぞ定例会 - Togetterまとめ</a></li>
 </ul>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/10/shell_lian_tower.html">Read more ...</a>
-                    <!-- <a href="../2014/04/10/shell_lian_tower.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -157,19 +157,19 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -203,10 +203,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/node-setagaya.html
+++ b/tag/node-setagaya.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,7 +72,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-13
                 </span>
-                <h2><a href="../2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
                 <div class="summary"><p>しばらくの間参加できていなかった <tt class="docutils literal"><span class="pre">NODE-Setagaya</span></tt> に参加&amp; <tt class="docutils literal">Terminal</tt> の <tt class="docutils literal">Tips</tt> 的なものを話してきました。
 当日利用したスライドはこちら。</p>
 <div style="width: 65%">
@@ -80,8 +80,8 @@
 </div><p><a class="reference external" href="https://speakerdeck.com/laughk/cli-mini-hack-number-1-terminaltofalseqin-mu-woshen-meyou">Cli mini Hack!#1 ~Terminalとの親睦を深めよう~</a></p>
 <s>Embed しようとすると Tinkerer のビルドが何故かコケるのでリンクのみ共有です。。</s><p><tt class="docutils literal">Pelican</tt> に以降したらコケなくなったので埋め込みました！</p>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/13/node_setagaya9_repo.html">Read more ...</a>
-                    <!-- <a href="../2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -117,7 +117,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
@@ -151,10 +151,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/none.html
+++ b/tag/none.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,7 +72,7 @@
                     <i class="fa fa-calendar"></i>
                         2013-11-18
                 </span>
-                <h2><a href="../2013/11/18/hello_new_blog.html">ブログ移転</a></h2>
+                <h2><a href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">ブログ移転</a></h2>
                 <div class="summary"><p>これまでたまに <a class="reference external" href="http://laugh-labo.blogspot.com">ラフなラボ</a> の方でブログを書いてましたが
 もう少し効率良くアウトプットしたいこともあって、
 tinkerer + githubpage のこちらの環境に移行しました。
@@ -83,8 +83,8 @@ tinkerer + githubpage のこちらの環境に移行しました。
 <p>このブログを立てる際の作業ログも後ほどまとめる予定。
 ほとんど自分で面倒見なければいけないのはなかなか手間がかかった、、</p>
 
-                    <a class="btn btn-primary btn-xs" href="../2013/11/18/hello_new_blog.html">Read more ...</a>
-                    <!-- <a href="../2013/11/18/hello_new_blog.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -120,7 +120,7 @@ tinkerer + githubpage のこちらの環境に移行しました。
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2013/11/18/hello_new_blog.html">
+        <a href="http://memo.laughk.org/2013/11/18/hello_new_blog.html">
             ブログ移転
         </a>
     </li>
@@ -154,10 +154,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/qpstudy.html
+++ b/tag/qpstudy.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,14 +72,14 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-21
                 </span>
-                <h2><a href="../2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">#qpstudy 2014.04 に参加してきたんで自分用まとめとか</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">だいぶ出遅れてしまいましたが、先週末 <a class="reference external" href="http://www.zusaar.com/event/4897007">qpstudy 2014.04</a> に一般枠で参加させてもらってきたので</div>
 <div class="line">感想や学びになったことのまとめをメモしておきます。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/21/qpstudy_20140419_report.html">Read more ...</a>
-                    <!-- <a href="../2014/04/21/qpstudy_20140419_report.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -115,7 +115,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/21/qpstudy_20140419_report.html">
+        <a href="http://memo.laughk.org/2014/04/21/qpstudy_20140419_report.html">
             #qpstudy 2014.04 に参加してきたんで自分用まとめとか
         </a>
     </li>
@@ -149,10 +149,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/shellscript.html
+++ b/tag/shellscript.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,7 +72,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-24
                 </span>
-                <h2><a href="../2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話</a></h2>
                 <div class="summary"><dl class="docutils">
 <dt>※ 2014-04-26</dt>
 <dd><div class="first last line-block">
@@ -91,8 +91,8 @@
 <div class="line">本当に参考になりました。ありがとうございます。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/24/shell_exec_log.html">Read more ...</a>
-                    <!-- <a href="../2014/04/24/shell_exec_log.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -128,7 +128,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/24/shell_exec_log.html">
+        <a href="http://memo.laughk.org/2014/04/24/shell_exec_log.html">
             シェルスクリプトが '&gt; $logfile 2&gt;&amp;1' だらけにならなくて済んだ話
         </a>
     </li>
@@ -162,10 +162,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/shieruyun.html
+++ b/tag/shieruyun.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,7 +72,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-13
                 </span>
-                <h2><a href="../2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
                 <div class="summary"><p>しばらくの間参加できていなかった <tt class="docutils literal"><span class="pre">NODE-Setagaya</span></tt> に参加&amp; <tt class="docutils literal">Terminal</tt> の <tt class="docutils literal">Tips</tt> 的なものを話してきました。
 当日利用したスライドはこちら。</p>
 <div style="width: 65%">
@@ -80,8 +80,8 @@
 </div><p><a class="reference external" href="https://speakerdeck.com/laughk/cli-mini-hack-number-1-terminaltofalseqin-mu-woshen-meyou">Cli mini Hack!#1 ~Terminalとの親睦を深めよう~</a></p>
 <s>Embed しようとすると Tinkerer のビルドが何故かコケるのでリンクのみ共有です。。</s><p><tt class="docutils literal">Pelican</tt> に以降したらコケなくなったので埋め込みました！</p>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/13/node_setagaya9_repo.html">Read more ...</a>
-                    <!-- <a href="../2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -90,7 +90,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-10
                 </span>
-                <h2><a href="../2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">ブログ更新自体がかなりお久しぶりです。</div>
 <div class="line">何とか生きてました。身の回りの環境が最近がらりと変わったわけですが、</div>
@@ -104,8 +104,8 @@
 <li><a class="reference external" href="http://togetter.com/li/651837">第10回記念シェル芸勉強会&#64;シェルリアンタワー&amp;第28回場所が未定だったが決まったぞ定例会 - Togetterまとめ</a></li>
 </ul>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/10/shell_lian_tower.html">Read more ...</a>
-                    <!-- <a href="../2014/04/10/shell_lian_tower.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -141,13 +141,13 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -181,10 +181,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/terminal.html
+++ b/tag/terminal.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,7 +72,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-13
                 </span>
-                <h2><a href="../2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
                 <div class="summary"><p>しばらくの間参加できていなかった <tt class="docutils literal"><span class="pre">NODE-Setagaya</span></tt> に参加&amp; <tt class="docutils literal">Terminal</tt> の <tt class="docutils literal">Tips</tt> 的なものを話してきました。
 当日利用したスライドはこちら。</p>
 <div style="width: 65%">
@@ -80,8 +80,8 @@
 </div><p><a class="reference external" href="https://speakerdeck.com/laughk/cli-mini-hack-number-1-terminaltofalseqin-mu-woshen-meyou">Cli mini Hack!#1 ~Terminalとの親睦を深めよう~</a></p>
 <s>Embed しようとすると Tinkerer のビルドが何故かコケるのでリンクのみ共有です。。</s><p><tt class="docutils literal">Pelican</tt> に以降したらコケなくなったので埋め込みました！</p>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/13/node_setagaya9_repo.html">Read more ...</a>
-                    <!-- <a href="../2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -90,15 +90,15 @@
                     <i class="fa fa-calendar"></i>
                         2013-11-21
                 </span>
-                <h2><a href="../2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></h2>
+                <h2><a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">前から tmux と組み合わせて irc bouncer 的な使い方をしていた weechat ですが。</div>
 <div class="line">いい加減本格的に移行したのでメモ。</div>
 <div class="line">ちなみに私は今のところ Ubuntu13.10 な 24時間起動のサーバ立てて使っとります。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="../2013/11/21/irc_setup_in_terminal.html">Read more ...</a>
-                    <!-- <a href="../2013/11/21/irc_setup_in_terminal.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -134,13 +134,13 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2013/11/21/irc_setup_in_terminal.html">
+        <a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">
             快適Terminal環境計画 - IRC -
         </a>
     </li>
@@ -174,10 +174,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/vim.html
+++ b/tag/vim.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,7 +72,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-13
                 </span>
-                <h2><a href="../2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">NODE-SetagayaでTerminalのTips的なものを話してきた</a></h2>
                 <div class="summary"><p>しばらくの間参加できていなかった <tt class="docutils literal"><span class="pre">NODE-Setagaya</span></tt> に参加&amp; <tt class="docutils literal">Terminal</tt> の <tt class="docutils literal">Tips</tt> 的なものを話してきました。
 当日利用したスライドはこちら。</p>
 <div style="width: 65%">
@@ -80,8 +80,8 @@
 </div><p><a class="reference external" href="https://speakerdeck.com/laughk/cli-mini-hack-number-1-terminaltofalseqin-mu-woshen-meyou">Cli mini Hack!#1 ~Terminalとの親睦を深めよう~</a></p>
 <s>Embed しようとすると Tinkerer のビルドが何故かコケるのでリンクのみ共有です。。</s><p><tt class="docutils literal">Pelican</tt> に以降したらコケなくなったので埋め込みました！</p>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/13/node_setagaya9_repo.html">Read more ...</a>
-                    <!-- <a href="../2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -117,7 +117,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/13/node_setagaya9_repo.html">
+        <a href="http://memo.laughk.org/2014/04/13/node_setagaya9_repo.html">
             NODE-SetagayaでTerminalのTips的なものを話してきた
         </a>
     </li>
@@ -151,10 +151,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/weechat.html
+++ b/tag/weechat.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,15 +72,15 @@
                     <i class="fa fa-calendar"></i>
                         2013-11-21
                 </span>
-                <h2><a href="../2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></h2>
+                <h2><a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">快適Terminal環境計画 - IRC -</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">前から tmux と組み合わせて irc bouncer 的な使い方をしていた weechat ですが。</div>
 <div class="line">いい加減本格的に移行したのでメモ。</div>
 <div class="line">ちなみに私は今のところ Ubuntu13.10 な 24時間起動のサーバ立てて使っとります。</div>
 </div>
 
-                    <a class="btn btn-primary btn-xs" href="../2013/11/21/irc_setup_in_terminal.html">Read more ...</a>
-                    <!-- <a href="../2013/11/21/irc_setup_in_terminal.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -116,7 +116,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2013/11/21/irc_setup_in_terminal.html">
+        <a href="http://memo.laughk.org/2013/11/21/irc_setup_in_terminal.html">
             快適Terminal環境計画 - IRC -
         </a>
     </li>
@@ -150,10 +150,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/tag/xargs.html
+++ b/tag/xargs.html
@@ -9,25 +9,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="../images/favicon.ico" rel="icon">
+    <link href="http://memo.laughk.org/images/favicon.ico" rel="icon">
 
     <!-- Open Graph tags -->
             <meta property="og:type" content="website"/>
             <meta property="og:title" content="続・ラフなラボ"/>
-            <meta property="og:url" content=".."/>
+            <meta property="og:url" content="http://memo.laughk.org"/>
             <meta property="og:description" content="続・ラフなラボ"/>
 
     <!-- Bootstrap -->
-        <link rel="stylesheet" href="../theme/css/bootstrap.cosmo.min.css" type="text/css"/>
-    <link href="../theme/css/font-awesome.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="http://memo.laughk.org/theme/css/bootstrap.cosmo.min.css" type="text/css"/>
+    <link href="http://memo.laughk.org/theme/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="../theme/css/pygments/solarizeddark.css" rel="stylesheet">
-    <link rel="stylesheet" href="../theme/css/style.css" type="text/css"/>
-        <link href="../static/custom.css" rel="stylesheet">
+    <link href="http://memo.laughk.org/theme/css/pygments/solarizeddark.css" rel="stylesheet">
+    <link rel="stylesheet" href="http://memo.laughk.org/theme/css/style.css" type="text/css"/>
+        <link href="http://memo.laughk.org/static/custom.css" rel="stylesheet">
 
-        <link href="../atom.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/atom.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ ATOM Feed"/>
-        <link href="../rss.xml" type="application/atom+xml" rel="alternate"
+        <link href="http://memo.laughk.org/rss.xml" type="application/atom+xml" rel="alternate"
               title="続・ラフなラボ RSS Feed"/>
 
 </head>
@@ -42,7 +42,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="../" class="navbar-brand">
+            <a href="http://memo.laughk.org/" class="navbar-brand">
 続・ラフなラボ            </a>
         </div>
         <div class="collapse navbar-collapse navbar-ex1-collapse">
@@ -51,12 +51,12 @@
                     <li><a href="/rss.xml"><i class="fa fa-rss"></i>RSS</a></li>
                     <li><a href="https://twitter.com/laugh_k"><i class="fa fa-twitter"></i>twitter</a></li>
                     <li><a href="https://github.com/laughk"><i class="fa fa-github"></i>Github</a></li>
-                         <li><a href="../pages/about.html">
+                         <li><a href="http://memo.laughk.org/pages/about.html">
                              About Me
                           </a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="../archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+                <li><a href="http://memo.laughk.org/archives"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
             </ul>
         </div>
         <!-- /.navbar-collapse -->
@@ -72,7 +72,7 @@
                     <i class="fa fa-calendar"></i>
                         2014-04-10
                 </span>
-                <h2><a href="../2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
+                <h2><a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">久々に第10回記念シェル芸勉強会行ってきたんでまとめとか</a></h2>
                 <div class="summary"><div class="line-block">
 <div class="line">ブログ更新自体がかなりお久しぶりです。</div>
 <div class="line">何とか生きてました。身の回りの環境が最近がらりと変わったわけですが、</div>
@@ -86,8 +86,8 @@
 <li><a class="reference external" href="http://togetter.com/li/651837">第10回記念シェル芸勉強会&#64;シェルリアンタワー&amp;第28回場所が未定だったが決まったぞ定例会 - Togetterまとめ</a></li>
 </ul>
 
-                    <a class="btn btn-primary btn-xs" href="../2014/04/10/shell_lian_tower.html">Read more ...</a>
-                    <!-- <a href="../2014/04/10/shell_lian_tower.html">Read more ...</a> -->
+                    <a class="btn btn-primary btn-xs" href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a>
+                    <!-- <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">Read more ...</a> -->
                 </div>
             </article>
             <hr/>
@@ -123,7 +123,7 @@
 <ul id="recentposts">
     <li class="list-group-item">
         <i class="fa fa-file-text fa-lg"></i>
-        <a href="../2014/04/10/shell_lian_tower.html">
+        <a href="http://memo.laughk.org/2014/04/10/shell_lian_tower.html">
             久々に第10回記念シェル芸勉強会行ってきたんでまとめとか
         </a>
     </li>
@@ -157,10 +157,10 @@ Hatena.BookmarkWidget.load();
 <script src="//code.jquery.com/jquery.js"></script>
 
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="../theme/js/bootstrap.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/bootstrap.min.js"></script>
 
 <!-- Enable responsive features in IE8 with Respond.js (https://github.com/scottjehl/Respond) -->
-<script src="../theme/js/respond.min.js"></script>
+<script src="http://memo.laughk.org/theme/js/respond.min.js"></script>
 
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */


### PR DESCRIPTION
DisqusのJS内部のURLが相対パスになってしまっていたことが原因。
`pelicanconf.py` に以下を追記して解決

``` python
RELATIVE_URLS = False
```
