### PR TITLE
コンテンツとビルド環境統合の関係で gh-pages 用 gitignore 追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.python-version
+cache/
+content/
+output/
+pelican-plugins/
+*.pyc
+*.pid


### PR DESCRIPTION
pelican の設定ファイル類を管理外に
